### PR TITLE
Upgrade TLS to the latest version.

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [2014] [ForgeRock AS]"
+ * "Portions Copyrighted [2024] [Wren Security]"
  **/
 #ifndef __NETWORK_H__
 #define __NETWORK_H__
@@ -39,11 +40,8 @@ typedef enum {
 } AUTH_TYPE;
 
 enum {
-    SSLv3 = 1 << 0,
-    TLSv1 = 1 << 1,
-    TLSv11 = 1 << 2,
-    TLSv12 = 1 << 3,
-    SSL_VERSION_MASKS = 1 << 4
+    TLSv12 = 1 << 0,
+    TLSv13 = 1 << 1
 };
 
 typedef SSIZE_T ssize_t;

--- a/source/network.c
+++ b/source/network.c
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [2014] [ForgeRock AS]"
+ * "Portions Copyrighted [2024] [Wren Security]"
  **/
 #define WIN32_LEAN_AND_MEAN
 #define _WIN32_WINNT 0x0502
@@ -588,14 +589,10 @@ static int net_ssl_init_creds(net_t *c) {
         }
     }
 
-    if (c->ssl.version & SSLv3)
-        schannel_cred.grbitEnabledProtocols |= SP_PROT_SSL3_CLIENT;
-    if (c->ssl.version & TLSv1)
-        schannel_cred.grbitEnabledProtocols |= SP_PROT_TLS1_CLIENT;
-    if (c->ssl.version & TLSv11)
-        schannel_cred.grbitEnabledProtocols |= SP_PROT_TLS1_1_CLIENT;
     if (c->ssl.version & TLSv12)
         schannel_cred.grbitEnabledProtocols |= SP_PROT_TLS1_2_CLIENT;
+    if (c->ssl.version & TLSv13)
+        schannel_cred.grbitEnabledProtocols |= SP_PROT_TLS1_3_CLIENT;
 
     schannel_cred.dwFlags |= SCH_CRED_NO_DEFAULT_CREDS |
             SCH_CRED_MANUAL_CRED_VALIDATION |
@@ -1333,13 +1330,13 @@ net_t * net_connect_url(const char *url, const char *cfile, const char *cpass, u
                 net_connect_int(n);
                 if (n->sock != INVALID_SOCKET) {
                     if (n->url.ssl) {
-                        n->ssl.version = SSLv3 | TLSv1;
+                        n->ssl.version = TLSv13 | TLSv12;
                         n->ssl.verifypeer = 0;
                         /* CertGetCertificateChain could be slow when this is set to 1.
-                         *  Edit the “Certificate Path Validation Settings” in the group policy editor: 
+                         *  Edit the “Certificate Path Validation Settings” in the group policy editor:
                          *  Computer Configuration → Windows Settings → Public Key Policies → Certificate Path Validation Settings
-                         *  Change the timeout values to 5 seconds each like this: Default URL retrieval timeout (in seconds) = 5 
-                         *  Default path validation cumulative retrieval timeout (in seconds) = 5 
+                         *  Change the timeout values to 5 seconds each like this: Default URL retrieval timeout (in seconds) = 5
+                         *  Default path validation cumulative retrieval timeout (in seconds) = 5
                          */
                         n->ssl.cfile = (char *) cfile;
                         n->ssl.cpass = (char *) cpass;


### PR DESCRIPTION
This PR adds support for TLSv1.3. This version is now used as the default, with TLSv1.2 as a fallback.

I have checked that this change really does increase the TLS version used:

![image](https://github.com/WrenSecurity/wrenidm-ad-passwordchange-handler/assets/13997406/9bb154d2-af7a-423d-bae0-64119386e6b7)
